### PR TITLE
Remove Ruby 2.6 for latest activesupport

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The latest activesupport gem now requires Ruby 2.7, so we're removing 2.6 support.